### PR TITLE
Changed import of StarRate icon from MUI to a 2nd level import, which results in a much smaller webpack.

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/StarRatingSummary.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/StarRatingSummary.jsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-import { StarRate } from '@material-ui/icons';
+import StarRate from '@material-ui/icons/StarRate';
 import Icon from '@material-ui/core/Icon';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/StarRatingBar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/StarRatingBar.jsx
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 import Cancel from '@material-ui/icons/Cancel';
-import { StarRate } from '@material-ui/icons';
+import StarRate from '@material-ui/icons/StarRate';
 import Alert from 'AppComponents/Shared/Alert';
 import Api from 'AppData/api';
 import AuthManager from 'AppData/AuthManager';
@@ -221,7 +221,7 @@ class StarRatingBar extends React.Component {
                                                 <FormattedMessage defaultMessage='users' id='Apis.Listing.StarRatingBar.users' />
                                             )}
                                             {')'}
-                                        </Typography>  
+                                        </Typography>
                                     </>
                                 )}
                         </>


### PR DESCRIPTION
Fixes: https://github.com/wso2/product-apim/issues/9361